### PR TITLE
Add mingw support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,41 +25,43 @@ use std::env;
 use std::process::Command;
 
 fn main() {
-	let mut cfg = gcc::Config::new();
+    let mut cfg = gcc::Config::new();
     let env = env::var("TARGET").unwrap();
 
     cfg.file("nfd/src/nfd_common.c");
 
     if env.contains("darwin") {
-    	cfg.file("nfd/src/nfd_cocoa.m");
-    	cfg.compile("libnfd.a");
+        cfg.file("nfd/src/nfd_cocoa.m");
+        cfg.compile("libnfd.a");
         println!("cargo:rustc-link-lib=framework=AppKit");
     } else if env.contains("windows") {
-    	cfg.file("nfd/src/nfd_win.cpp");
-    	cfg.compile("libnfd.a");
+        cfg.file("nfd/src/nfd_win.cpp");
+        cfg.compile("libnfd.a");
         println!("cargo:rustc-link-lib=ole32");
+        // MinGW doesn't link it by default
+        println!("cargo:rustc-link-lib=uuid");
     } else {
-    	let pkg_output = Command::new("pkg-config")
-			.arg("--cflags")
-			.arg("gtk+-3.0")
-			.arg("glib-2.0")
-			.arg("--libs")
-			.arg("glib-2.0")
-			.output();
-    	match pkg_output {
-    		Ok(output) => {
-    			let t = String::from_utf8(output.stdout).unwrap();
-    			let flags = t.split(" ");
-    			for flag in flags {
-    				if flag != "\n" && flag != "" {
-    					cfg.flag(flag);
-    				}
-    			}
-    		}
-    		_ => (),
-    	}
-    	cfg.file("nfd/src/nfd_gtk.c");
-    	cfg.compile("libnfd.a");
+        let pkg_output = Command::new("pkg-config")
+            .arg("--cflags")
+            .arg("gtk+-3.0")
+            .arg("glib-2.0")
+            .arg("--libs")
+            .arg("glib-2.0")
+            .output();
+        match pkg_output {
+            Ok(output) => {
+                let t = String::from_utf8(output.stdout).unwrap();
+                let flags = t.split(" ");
+                for flag in flags {
+                    if flag != "\n" && flag != "" {
+                        cfg.flag(flag);
+                    }
+                }
+            }
+            _ => (),
+        }
+        cfg.file("nfd/src/nfd_gtk.c");
+        cfg.compile("libnfd.a");
         println!("cargo:rustc-link-lib=gdk-3");
         println!("cargo:rustc-link-lib=gtk-3");
         println!("cargo:rustc-link-lib=glib-2.0");

--- a/nfd/src/nfd_win.cpp
+++ b/nfd/src/nfd_win.cpp
@@ -9,6 +9,11 @@
 #define UNICODE
 #endif
 
+#ifdef __MINGW32__
+// Explicitly setting NTDDI version, this is necessary for the MinGW compiler
+#define NTDDI_VERSION NTDDI_VISTA
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#endif
 
 #include <wchar.h>
 #include <stdio.h>
@@ -359,13 +364,14 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
     HRESULT result = ::CoInitializeEx(NULL,
                                       ::COINIT_APARTMENTTHREADED |
                                       ::COINIT_DISABLE_OLE1DDE );
+
+    ::IFileOpenDialog *fileOpenDialog(NULL);
+
     if ( !SUCCEEDED(result))
     {
         NFDi_SetError("Could not initialize COM.");
         goto end;
     }
-
-    ::IFileOpenDialog *fileOpenDialog(NULL);
 
     // Create dialog
     result = ::CoCreateInstance(::CLSID_FileOpenDialog, NULL,


### PR DESCRIPTION
I've add support for MinGW and checked it with examples. Also I've changed indent for `build.rs` in accordance with styling guide (4 spaces). It contained mixed indent.

I added forced linking to `uuid` because it doesn't link for mingw dy default. Is there any conflict with VS environment?

Without `uuid` I take an error:
```
target\debug\libnfd.rlib(nfd_win.o):nfd_win.cpp:(.rdata$.refptr.CLSID_FileSaveDialog[.refptr.CLSID_FileSaveDialog]+0x0): undefined reference to `CLSID_FileSaveDialog'
```