### PR TITLE
DialogBuilder lifetime fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,6 @@ impl<'a> DialogBuilder<'a> {
         self
     }
 
-    pub fn dialog_type(&'a mut self, dialog_type: DialogType) -> &mut DialogBuilder {
-        self.dialog_type = dialog_type;
-        self
-    }
-
     pub fn open(&self) -> Result<Response> {
         open_dialog(self.filter, self.default_path, self.dialog_type.clone())
     }


### PR DESCRIPTION
I've found the case when compiler can't infer an appropriate lifetime. I use:
```rust
struct DialogWorker<'a> {
    path: Option<String>,
    filter: Option<String>,
    mode: Option<String>,
    builder: DialogBuilder<'a>,
}

impl<'a, CTX> Worker<CTX> for DialogWorker<'a> {

    fn shortcut(&mut self, _: &mut CTX) -> WorkerResult<Shortcut> {
        let res = match self.mode.as_ref().map(String::as_ref) {
            Some("open") | None => Ok(DialogType::SingleFile),
            Some("multiple") => Ok(DialogType::MultipleFiles),
            Some("save") => Ok(DialogType::SaveFile),
            Some(mode) => Err(WorkerError::Reject(format!("Unsupported mode {}", mode))),
        };
        let dt = try!(res);
        self.builder.dialog_type(dt);
        Ok(Shortcut::Tuned)
    }

```

`dialog_type` call produces compiler's error here. This PR makes possible to set `dialog_type` when builder is a field of a struct.

There is no changes if it uses chainly `dialog().dialog_type(...).open()`. Works fine before and now.

- - -

But one thing I've thought: do we need this method? If somebody uses builder multiple times, than It's necessary to provide possibility to reset a filter or a default path with `dialog().filter(None)`.

We can choose one strategy of:
1) Leave `dialog_type` method here and don't change `filter` and `path`
2) Change `filter(&str)` and `path(&str)` to `filter(Option<&str>)` and `path(Option<&str>)`
3) Remove `dialog_type` altogether (in this case anybody will use `open` function directly without a builder)

What is your opinion about it? If we choose 1 than the merger of this PR is enough.